### PR TITLE
PR: Greaser Lifecycle

### DIFF
--- a/__mocks__/shelljs.ts
+++ b/__mocks__/shelljs.ts
@@ -15,6 +15,7 @@ export default {
     silent: false,
     verbose: false
   },
+  echo: jest.fn(),
   exec: jest.fn().mockReturnValue({ stdout: '' }),
   exit: jest.fn(),
   which: jest.fn()

--- a/__tests__/__fixtures__/git-tags.fixture.ts
+++ b/__tests__/__fixtures__/git-tags.fixture.ts
@@ -1,13 +1,14 @@
-import type { GitSemverTagsOptions } from '@grease/types'
+import type { GitSemverTagsOptions, SemanticVersionTag } from '@grease/types'
 
 /**
  * @file Global Fixture - Git Semver Tags
  * @module tests/fixtures/git-tags
  */
 
-export const OPTIONS_LERNA: GitSemverTagsOptions = {
+export const TAGS_OPTIONS_LERNA: GitSemverTagsOptions = {
   lernaTags: true,
-  package: 'foo-package'
+  package: 'foo-package',
+  tagPrefix: '@'
 }
 
 export default [
@@ -22,4 +23,4 @@ export default [
   'v2.0.0',
   'v1.1.0-alpha.1',
   'v1.0.0'
-]
+] as SemanticVersionTag[]

--- a/packages/grease/src/config/constants.config.ts
+++ b/packages/grease/src/config/constants.config.ts
@@ -24,6 +24,12 @@ export const DEBUG_NAMESPACE = 'grease'
 export const DEBUG_NAMESPACE_COLOR = '111111111111'
 
 /**
+ * @property {string} GH_RELEASE_CREATE - Command to create releases via GH CLI
+ * @see https://cli.github.com/manual/gh_release_create
+ */
+export const GH_RELEASE_CREATE = 'gh release create'
+
+/**
  * @property {string} GREASER_NOTES_BIRTHDAY - `Greaser#notes` birthday format
  */
 export const GREASER_NOTES_BIRTHDAY = `## Overview

--- a/packages/grease/src/constraints/__tests__/is-sem-ver.constraint.functional.spec.ts
+++ b/packages/grease/src/constraints/__tests__/is-sem-ver.constraint.functional.spec.ts
@@ -3,7 +3,7 @@ import type { ObjectPlain } from '@flex-development/tutils'
 import type { IsSemVerOptions } from '@grease/interfaces'
 import type { GitSemverTagsOptions, SemanticVersion } from '@grease/types'
 import semver from '@grease/utils/semver.util'
-import { OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
+import { TAGS_OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
 import type { TestcaseCalled } from '@tests/utils/types'
 import type { ValidationArguments } from 'class-validator'
 import type { CoerceOptions } from 'semver'
@@ -34,9 +34,9 @@ describe('functional:grease/constraints/IsSemVerConstraint', () => {
     const CASES_GIT: CaseGit[] = [
       {
         call: 'call',
-        calledWith: OPTIONS_LERNA,
+        calledWith: TAGS_OPTIONS_LERNA,
         expected: 1,
-        git: OPTIONS_LERNA,
+        git: TAGS_OPTIONS_LERNA,
         value: version
       },
       { call: 'call', calledWith: {}, expected: 1, git: true, value: version }

--- a/packages/grease/src/decorators/__tests__/is-sem-ver.decorator.functional.spec.ts
+++ b/packages/grease/src/decorators/__tests__/is-sem-ver.decorator.functional.spec.ts
@@ -4,7 +4,7 @@ import Validator from '@grease/constraints/is-sem-ver.constraint'
 import { IsSemVerMessage as Msg } from '@grease/enums/is-sem-ver-message.enum'
 import type { IsSemVerOptions } from '@grease/interfaces'
 import type { SemanticVersion } from '@grease/types'
-import { OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
+import { TAGS_OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
 import type {
   IsSemVerOption as Option,
   TestcaseDecorator
@@ -78,7 +78,7 @@ describe('functional:grease/decorators/IsSemVer', () => {
           expected: EXPECTED,
           option: 'options.clean',
           options: { clean: true },
-          value: `${OPTIONS_LERNA.package}@${pkg.version}`
+          value: `${TAGS_OPTIONS_LERNA.package}@${pkg.version}`
         },
         {
           code: 'CMP',
@@ -176,7 +176,7 @@ describe('functional:grease/decorators/IsSemVer', () => {
         {
           expected: EXPECTED,
           option: 'options.git',
-          options: { each: true, git: OPTIONS_LERNA },
+          options: { each: true, git: TAGS_OPTIONS_LERNA },
           value: [version]
         },
         {

--- a/packages/grease/src/dtos/__tests__/create-release.dto.spec.ts
+++ b/packages/grease/src/dtos/__tests__/create-release.dto.spec.ts
@@ -1,0 +1,193 @@
+import pkg from '@/grease/package.json'
+import cache from '@grease/config/cache.config'
+import { GREASER_TITLE_BIRTHDAY } from '@grease/config/constants.config'
+import type { ICreateReleaseDTO } from '@grease/interfaces'
+import { GitSemverTagsOptions, SemanticVersion } from '@grease/types'
+import TAGS, {
+  TAGS_OPTIONS_LERNA as TOL
+} from '@tests/fixtures/git-tags.fixture'
+import type { Testcase } from '@tests/utils/types'
+import faker from 'faker'
+import join from 'lodash/join'
+import { mocked } from 'ts-jest/utils'
+import TestSubject from '../create-release.dto'
+
+/**
+ * @file Unit Tests - CreateReleaseDTO
+ * @module grease/dtos/tests/unit/CreateRelease
+ */
+
+jest.mock('@grease/config/cache.config')
+
+const mockCache = mocked(cache, true)
+
+describe('unit:dtos/CreateReleaseDTO', () => {
+  describe('#toString', () => {
+    type Case = Testcase<string> & {
+      dto: Partial<ICreateReleaseDTO>
+      git: GitSemverTagsOptions
+      property:
+        | `#${keyof ICreateReleaseDTO}`
+        | `release tag${' (lerna-style)' | ''}`
+        | `title if #version ${'satisifies' | 'does not satisfy'} 1.0.0`
+      stringify: 'stringify' | 'not stringify'
+    }
+
+    const V1TAG = TAGS[TAGS.length - 1]
+    const V1 = V1TAG.replace('v', '') as SemanticVersion
+    const files: string[] = ['CHANGELOG.md', 'LICENSE.md']
+    const notes = faker.lorem.words(5)
+    const notesFile = 'RELEASE_NOTES.md'
+    const tagPrefix = 'v'
+    const target = 'main'
+    const tag0 = TAGS[0]
+    const version0 = tag0.replace('v', '') as SemanticVersion
+
+    const cases: Case[] = [
+      {
+        dto: { tagPrefix, version: version0 },
+        expected: tag0,
+        git: {},
+        property: 'release tag',
+        stringify: 'stringify'
+      },
+      {
+        dto: { tagPrefix: TOL.tagPrefix, version: version0 },
+        expected: `${TOL.package}${TOL.tagPrefix}${version0}`,
+        git: TOL,
+        property: 'release tag (lerna-style)',
+        stringify: 'stringify'
+      },
+      {
+        dto: { files },
+        expected: join(files, ' '),
+        git: {},
+        property: '#files',
+        stringify: 'stringify'
+      },
+      {
+        dto: { files: [] },
+        expected: '',
+        git: {},
+        property: '#files',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { draft: true },
+        expected: '--draft',
+        git: {},
+        property: '#draft',
+        stringify: 'stringify'
+      },
+      {
+        dto: { draft: false },
+        expected: '',
+        git: {},
+        property: '#draft',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { notes },
+        expected: `--notes ${notes}`,
+        git: {},
+        property: '#notes',
+        stringify: 'stringify'
+      },
+      {
+        dto: { notes: '' },
+        expected: '',
+        git: {},
+        property: '#notes',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { notesFile },
+        expected: `--notes-file ${notesFile}`,
+        git: {},
+        property: '#notesFile',
+        stringify: 'stringify'
+      },
+      {
+        dto: { notesFile: '' },
+        expected: '',
+        git: {},
+        property: '#notesFile',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { prerelease: true },
+        expected: '--prerelease',
+        git: {},
+        property: '#prerelease',
+        stringify: 'stringify'
+      },
+      {
+        dto: { prerelease: false },
+        expected: '',
+        git: {},
+        property: '#prerelease',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { target },
+        expected: `--target ${target}`,
+        git: {},
+        property: '#target',
+        stringify: 'stringify'
+      },
+      {
+        dto: { target: '' },
+        expected: '',
+        git: {},
+        property: '#target',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { repo: pkg.homepage },
+        expected: `--repo ${pkg.homepage}`,
+        git: {},
+        property: '#repo',
+        stringify: 'stringify'
+      },
+      {
+        dto: { repo: '' },
+        expected: '',
+        git: {},
+        property: '#repo',
+        stringify: 'not stringify'
+      },
+      {
+        dto: { tagPrefix, version: V1 },
+        expected: `${V1TAG} --title ${V1TAG} ${GREASER_TITLE_BIRTHDAY}`,
+        git: {},
+        property: 'title if #version satisifies 1.0.0',
+        stringify: 'stringify'
+      },
+      {
+        dto: { tagPrefix, title: tag0, version: version0 },
+        expected: `${tag0} --title ${tag0}`,
+        git: {},
+        property: 'title if #version does not satisfy 1.0.0',
+        stringify: 'stringify'
+      },
+      {
+        dto: { title: '' },
+        expected: '',
+        git: {},
+        property: '#title',
+        stringify: 'not stringify'
+      }
+    ]
+
+    it.each<Case>(cases)('should $stringify $property', testcase => {
+      // Arrange
+      const { dto, expected, git } = testcase
+
+      // @ts-expect-error read-only property - mocking
+      mockCache.git = git
+
+      // Act + Expect
+      expect(Object.assign(new TestSubject(), dto).toString()).toBe(expected)
+    })
+  })
+})

--- a/packages/grease/src/dtos/create-release.dto.ts
+++ b/packages/grease/src/dtos/create-release.dto.ts
@@ -1,0 +1,124 @@
+import cache from '@grease/config/cache.config'
+import { GREASER_TITLE_BIRTHDAY } from '@grease/config/constants.config'
+import IsPath from '@grease/decorators/is-path.decorator'
+import IsSemVer from '@grease/decorators/is-sem-ver.decorator'
+import IsTargetBranch from '@grease/decorators/is-target-branch.decorator'
+import type { ICreateReleaseDTO } from '@grease/interfaces'
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+import join from 'lodash/join'
+
+/**
+ * @file Data Transfer Objects - CreateReleaseDTO
+ * @module grease/dtos/CreateRelease
+ */
+
+/**
+ * Data used to create a [GitHub release via the GitHub CLI][1].
+ *
+ * [1]: https://cli.github.com/manual/gh_release_create
+ *
+ * @implements {ICreateReleaseDTO}
+ */
+export default class CreateReleaseDTO implements ICreateReleaseDTO {
+  @IsBoolean()
+  @IsOptional()
+  draft?: ICreateReleaseDTO['draft']
+
+  @IsPath({ each: true, exists: true, gh: true })
+  @IsOptional()
+  files?: ICreateReleaseDTO['files']
+
+  @IsString()
+  @IsOptional()
+  notes?: ICreateReleaseDTO['notes']
+
+  @IsPath({ exists: true })
+  @IsOptional()
+  notesFile?: ICreateReleaseDTO['notesFile']
+
+  @IsBoolean()
+  @IsOptional()
+  prerelease?: ICreateReleaseDTO['prerelease']
+
+  @IsNotEmpty()
+  @IsOptional()
+  repo?: ICreateReleaseDTO['repo']
+
+  @IsNotEmpty()
+  @IsOptional()
+  tagPrefix?: ICreateReleaseDTO['tagPrefix']
+
+  @IsTargetBranch({ sha: true })
+  @IsOptional()
+  target?: ICreateReleaseDTO['target']
+
+  @IsNotEmpty()
+  @IsOptional()
+  title?: ICreateReleaseDTO['title']
+
+  @IsSemVer({ git: cache.git, negit: true })
+  version: ICreateReleaseDTO['version']
+
+  /**
+   * Converts the DTO into a [`gh release create`][1] argument string.
+   *
+   * [1]: https://cli.github.com/manual/gh_release_create
+   *
+   * @todo Handle lerna tags
+   *
+   * @return {string} `gh release create` arguments
+   */
+  toString(): string {
+    // Spread data
+    const {
+      draft = false,
+      files = [],
+      notes = '',
+      notesFile = '',
+      prerelease,
+      repo = '',
+      tagPrefix = '',
+      target = '',
+      title = '',
+      version = ''
+    } = this
+
+    // Get release tag
+    const tag: string = `${cache.git?.package ?? ''}${tagPrefix}${version}`
+
+    // Init command arguments array
+    const args: string[] = [tag]
+
+    // Add release asset files
+    if (files && files.length) args.push(join(files, ' '))
+
+    // Save release as draft or publish
+    if (draft) args.push('--draft')
+
+    // Add release notes
+    if (notes && notes.length) args.push(`--notes ${notes}`)
+
+    // Read release notes from file
+    if (notesFile && notesFile.toString().length) {
+      args.push(`--notes-file ${notesFile}`)
+    }
+
+    // Mark as prerelease
+    if (prerelease) args.push('--prerelease')
+
+    // Target branch or commit sha
+    if (target && target.length) args.push(`--target ${target}`)
+
+    // Push release to different repository
+    if (repo && repo.length) args.push(`--repo ${repo}`)
+
+    // Add release title
+    if (version === '1.0.0') {
+      args.push(`--title ${tag} ${GREASER_TITLE_BIRTHDAY}`)
+    } else if (title && title.length) {
+      args.push(`--title ${title}`)
+    }
+
+    return join(args, ' ').trim()
+  }
+}

--- a/packages/grease/src/interfaces/create-release-dto.interface.ts
+++ b/packages/grease/src/interfaces/create-release-dto.interface.ts
@@ -1,0 +1,64 @@
+import type { PathLike, SemanticVersion } from '@grease/types'
+
+/**
+ * @file Interfaces - ICreateReleaseDTO
+ * @module grease/interfaces/ICreateReleaseDTO
+ */
+
+export interface ICreateReleaseDTO {
+  /**
+   * Save release as a draft instead of publishing it.
+   *
+   * @default true
+   */
+  draft?: boolean
+
+  /**
+   * Release asset paths.
+   */
+  files?: PathLike[]
+
+  /**
+   * Release notes.
+   */
+  notes?: string
+
+  /**
+   * Read release notes from file.
+   */
+  notesFile?: PathLike
+
+  /**
+   * Mark as a prerelease.
+   */
+  prerelease?: boolean
+
+  /**
+   * Select another repository using the `[HOST/]OWNER/REPO` format.
+   */
+  repo?: string
+
+  /**
+   * Release tag prefix.
+   *
+   * @default 'v'
+   */
+  tagPrefix?: string
+
+  /**
+   * Target branch or full commit SHA.
+   *
+   * @default 'main'
+   */
+  target?: string
+
+  /**
+   * Release title.
+   */
+  title?: string
+
+  /**
+   * Version being released.
+   */
+  version: SemanticVersion
+}

--- a/packages/grease/src/interfaces/index.ts
+++ b/packages/grease/src/interfaces/index.ts
@@ -3,6 +3,7 @@
  * @module grease/interfaces
  */
 
+export type { ICreateReleaseDTO } from './create-release-dto.interface'
 export type { IGreaseCache } from './grease-cache.interface'
 export type { IGreaseOptions } from './grease-options.interface'
 export type { IGreaseScripts } from './grease-scripts.interface'

--- a/packages/grease/src/lifecycles/__tests__/greaser.lifecycle.functional.spec.ts
+++ b/packages/grease/src/lifecycles/__tests__/greaser.lifecycle.functional.spec.ts
@@ -4,13 +4,13 @@ import sh from 'shelljs'
 import TestSubject from '../greaser.lifecycle'
 
 /**
- * @file Unit Tests - Greaser
- * @module grease/lifecycles/tests/unit/Greaser
+ * @file Functional Tests - Greaser
+ * @module grease/lifecycles/tests/functional/Greaser
  */
 
 const mockSH = sh as jest.Mocked<typeof sh>
 
-describe('unit:lifecycles/greaser', () => {
+describe('functional:lifecycles/greaser', () => {
   beforeEach(async () => {
     await TestSubject({ version: '3.13.98-rc.6.40' })
   })

--- a/packages/grease/src/lifecycles/__tests__/greaser.lifecycle.functional.spec.ts
+++ b/packages/grease/src/lifecycles/__tests__/greaser.lifecycle.functional.spec.ts
@@ -1,0 +1,27 @@
+import { GH_RELEASE_CREATE } from '@grease/config/constants.config'
+import { ExitCode } from '@grease/enums/exit-code.enum'
+import sh from 'shelljs'
+import TestSubject from '../greaser.lifecycle'
+
+/**
+ * @file Unit Tests - Greaser
+ * @module grease/lifecycles/tests/unit/Greaser
+ */
+
+const mockSH = sh as jest.Mocked<typeof sh>
+
+describe('unit:lifecycles/greaser', () => {
+  beforeEach(async () => {
+    await TestSubject({ version: '3.13.98-rc.6.40' })
+  })
+
+  it(`should execute ${GH_RELEASE_CREATE} command`, () => {
+    expect(mockSH.exec).toBeCalledTimes(1)
+    expect(mockSH.exec.mock.calls[0][0]).toMatch(GH_RELEASE_CREATE)
+  })
+
+  it('should force shell to exit', () => {
+    expect(mockSH.exit).toBeCalledTimes(1)
+    expect(mockSH.exit).toBeCalledWith(ExitCode.SUCCESS)
+  })
+})

--- a/packages/grease/src/lifecycles/greaser.lifecycle.ts
+++ b/packages/grease/src/lifecycles/greaser.lifecycle.ts
@@ -1,0 +1,34 @@
+import type { ObjectPlain } from '@flex-development/tutils'
+import { GH_RELEASE_CREATE } from '@grease/config/constants.config'
+import CreateReleaseDTO from '@grease/dtos/create-release.dto'
+import { ExitCode } from '@grease/enums/exit-code.enum'
+import type { ICreateReleaseDTO as DTO } from '@grease/interfaces'
+import validate from '@grease/utils/validate.util'
+import sh from 'shelljs'
+
+/**
+ * @file Lifecycles - Greaser
+ * @module grease/lifecycles/Greaser
+ */
+
+/**
+ * Creates a GitHub release using the [GitHub CLI][1].
+ *
+ * [1]: https://cli.github.com/manual/gh_release_create
+ *
+ * @async
+ * @param {DTO | ObjectPlain} [dto={}] - Data to create release
+ * @return {Promise<never>} Function will force shell to exit
+ */
+const Greaser = async (dto: DTO | ObjectPlain = {}): Promise<never> => {
+  // Validate release data
+  const release = await validate(CreateReleaseDTO, dto, false)
+
+  // Execute GitHub release
+  sh.exec(`${GH_RELEASE_CREATE} ${release.toString()}`)
+
+  // Force shell to exit
+  return sh.exit(ExitCode.SUCCESS)
+}
+
+export default Greaser

--- a/packages/grease/src/services/__tests__/grease-cache.service.functional.spec.ts
+++ b/packages/grease/src/services/__tests__/grease-cache.service.functional.spec.ts
@@ -1,6 +1,6 @@
 import type { IGreaseOptions } from '@grease/interfaces'
 import validate from '@grease/utils/validate.util'
-import { OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
+import { TAGS_OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
 import { mocked } from 'ts-jest/utils'
 import TestSubject from '../grease-cache.service'
 
@@ -16,7 +16,11 @@ const mockValidate = mocked(validate)
 describe('functional:services/GreaseCache', () => {
   const Subject = new TestSubject()
 
-  const options: IGreaseOptions = { lernaPackage: OPTIONS_LERNA.package }
+  const options: IGreaseOptions = {
+    lernaPackage: TAGS_OPTIONS_LERNA.package,
+    tagPrefix: TAGS_OPTIONS_LERNA.tagPrefix,
+    skipUnstable: TAGS_OPTIONS_LERNA.skipUnstable
+  }
 
   describe('#init', () => {
     beforeEach(async () => {

--- a/packages/grease/src/services/__tests__/grease-cache.service.spec.ts
+++ b/packages/grease/src/services/__tests__/grease-cache.service.spec.ts
@@ -1,7 +1,7 @@
 import type { IGreaseOptions } from '@grease/interfaces'
 import type { GitSemverTagsOptions } from '@grease/types'
 import validate from '@grease/utils/validate.util'
-import { OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
+import { TAGS_OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
 import type { Testcase } from '@tests/utils/types'
 import { mocked } from 'ts-jest/utils'
 import TestSubject from '../grease-cache.service'
@@ -18,7 +18,11 @@ const mockValidate = mocked(validate)
 describe('unit:services/GreaseCache', () => {
   const Subject = new TestSubject()
 
-  const options: IGreaseOptions = { lernaPackage: OPTIONS_LERNA.package }
+  const options: IGreaseOptions = {
+    lernaPackage: TAGS_OPTIONS_LERNA.package,
+    tagPrefix: TAGS_OPTIONS_LERNA.tagPrefix,
+    skipUnstable: TAGS_OPTIONS_LERNA.skipUnstable
+  }
 
   describe('get git', () => {
     type Case = Testcase<GitSemverTagsOptions> & {
@@ -28,7 +32,7 @@ describe('unit:services/GreaseCache', () => {
 
     const cases: Case[] = [
       { expected: {}, options: {}, ready: false },
-      { expected: OPTIONS_LERNA, options, ready: true }
+      { expected: TAGS_OPTIONS_LERNA, options: options, ready: true }
     ]
 
     const name = 'should return $expected if ready === $ready'

--- a/packages/grease/src/types/semver.types.ts
+++ b/packages/grease/src/types/semver.types.ts
@@ -44,6 +44,11 @@ export type SemanticVersionUnstable =
  */
 export type SemanticVersion = SemanticVersionStable | SemanticVersionUnstable
 
+/**
+ * Semantic version (stable and unstable) with tag prefix string schema.
+ */
+export type SemanticVersionTag = `${string | ''}${SemanticVersion}`
+
 // Rename `git-semver-tag` and `semver` type definitions
 export type {
   Callback as GitSemverTagsCallback,

--- a/packages/grease/src/utils/__tests__/semver.util.spec.ts
+++ b/packages/grease/src/utils/__tests__/semver.util.spec.ts
@@ -4,7 +4,7 @@ import type {
   SemanticVersion,
   SemVerOptions
 } from '@grease/types'
-import { OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
+import { TAGS_OPTIONS_LERNA } from '@tests/fixtures/git-tags.fixture'
 import { mockGitTags, stringCompare } from '@tests/utils'
 import type { Testcase } from '@tests/utils/types'
 import TestSubject from '../semver.util'
@@ -35,13 +35,13 @@ describe('unit:utils/semver', () => {
         expected: VERSION,
         options: undefined,
         tagPrefix: '@',
-        version: `${OPTIONS_LERNA.package}@${pkg.version}`
+        version: `${TAGS_OPTIONS_LERNA.package}@${pkg.version}`
       },
       {
         expected: null,
         options: undefined,
         tagPrefix: undefined,
-        version: `${OPTIONS_LERNA.package}@${pkg.version}`
+        version: `${TAGS_OPTIONS_LERNA.package}@${pkg.version}`
       },
       {
         expected: null,
@@ -67,7 +67,7 @@ describe('unit:utils/semver', () => {
     }
 
     const tags = mockGitTags()
-    const tagsLerna = mockGitTags(OPTIONS_LERNA)
+    const tagsLerna = mockGitTags(TAGS_OPTIONS_LERNA)
 
     const cases: Case[] = [
       {
@@ -82,12 +82,12 @@ describe('unit:utils/semver', () => {
       },
       {
         expected: tagsLerna,
-        options: OPTIONS_LERNA,
+        options: TAGS_OPTIONS_LERNA,
         reverse: true
       },
       {
         expected: tagsLerna.sort(stringCompare),
-        options: OPTIONS_LERNA,
+        options: TAGS_OPTIONS_LERNA,
         reverse: false
       }
     ]


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->
 
Implemented the `greaser` lifecycle to create GitHub releases using the [GitHub CLI][1].

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

```zsh
 PASS   grease  packages/grease/src/dtos/__tests__/create-release.dto.spec.ts
  unit:dtos/CreateReleaseDTO
    #toString
      ✓ should stringify release tag (2 ms)
      ✓ should stringify release tag (lerna-style)
      ✓ should stringify #files
      ✓ should not stringify #files
      ✓ should stringify #draft
      ✓ should not stringify #draft
      ✓ should stringify #notes
      ✓ should not stringify #notes
      ✓ should stringify #notesFile
      ✓ should not stringify #notesFile
      ✓ should stringify #prerelease
      ✓ should not stringify #prerelease (1 ms)
      ✓ should stringify #target
      ✓ should not stringify #target (1 ms)
      ✓ should stringify #repo (1 ms)
      ✓ should not stringify #repo
      ✓ should stringify title if #version satisifies 1.0.0 (1 ms)
      ✓ should stringify title if #version does not satisfy 1.0.0
      ✓ should not stringify #title (1 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        3.846 s
Ran all test suites matching /create-release.dto/i.
```

```zsh
 PASS   grease  packages/grease/src/lifecycles/__tests__/greaser.lifecycle.functional.spec.ts
  functional:lifecycles/greaser
    ✓ should execute gh release create command (45 ms)
    ✓ should force shell to exit (2 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.942 s, estimated 4 s
Ran all test suites matching /greaser/i.
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

- Project maintainers are expected to use `options.pregreaser` to handle creating and/or moving release assets. All assets must exist (asset display labels are allowed) within the filesystem or an error will be echoed to the shell. 

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

[P010-14][2]

## Submission checklist

- [x] pr title prefixed with `PR:` (e.g: `PR: User authentication`)
- [x] pr title describes functionality (not vague title like `Update index.md`)
- [x] pr targets branch `next`
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://cli.github.com/manual/gh_release_create
[2]: https://flexdevelopment.atlassian.net/browse/P010-14
