### PR TITLE
PR: Fix CreateReleaseDTO#version failure when options.skip.tag is true

### DIFF
--- a/packages/grease/src/dtos/create-release.dto.ts
+++ b/packages/grease/src/dtos/create-release.dto.ts
@@ -1,5 +1,5 @@
 import type { ObjectPlain } from '@flex-development/tutils'
-import cache from '@grease/config/cache.config'
+import $c from '@grease/config/cache.config'
 import { GREASER_TITLE_BIRTHDAY } from '@grease/config/constants.config'
 import IsPath from '@grease/decorators/is-path.decorator'
 import IsSemVer from '@grease/decorators/is-sem-ver.decorator'
@@ -28,7 +28,7 @@ export default class CreateReleaseDTO implements ICreateReleaseDTO {
 
   @IsPath({ each: true, exists: false, gh: true })
   @IsOptional()
-  @ValidateIf(() => cache.options.dryRun === false)
+  @ValidateIf(() => $c.options.dryRun === false)
   readonly files?: ICreateReleaseDTO['files']
 
   @IsString()
@@ -47,7 +47,7 @@ export default class CreateReleaseDTO implements ICreateReleaseDTO {
   @IsOptional()
   readonly repo?: ICreateReleaseDTO['repo']
 
-  @IsTargetBranch({ dir: cache.options.gitdir, sha: true })
+  @IsTargetBranch({ dir: $c.options.gitdir, sha: true })
   @IsOptional()
   readonly target?: ICreateReleaseDTO['target']
 
@@ -55,8 +55,8 @@ export default class CreateReleaseDTO implements ICreateReleaseDTO {
   @IsOptional()
   readonly title?: ICreateReleaseDTO['title']
 
-  @IsSemVer({ clean: true, git: () => cache.git })
-  @ValidateIf(() => cache.options.dryRun === false)
+  @IsSemVer({ clean: true, git: () => $c.git })
+  @ValidateIf(() => !$c.options.dryRun && !$c.options.skip?.tag)
   readonly version: ICreateReleaseDTO['version']
 
   /**


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

Fixed the validation logic for `CreateReleaseDTO#version`. Validation will be skipped during dry runs **and when the `tag` lifecycle is skipped**. This will allow maintainers to create and push tags at other points in their release workflow (see the `publish-release` job in our [Continuous Deployment][1] workflow for an example).

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

- Ran [release workflow script with `options.skip.tag` set to `true`][2] to ensure error was resolved
- Re-ran all test suites, run `yarn test` after pulling branch to see full output

    ```zsh
      Test Suites: 32 passed, 32 total
      Tests:       1 skipped, 217 passed, 218 total
      Snapshots:   0 total
      Time:        27.039 s
      Ran all test suites.
    ```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

fixes #12, fixes [P010-26]

## Submission checklist

- [x] pr title prefixed with `PR:` (e.g: `PR: User authentication`)
- [x] pr title describes functionality (not vague title like `Update index.md`)
- [x] pr targets branch `next`
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/flex-development/grease/blob/182fd184a7c64dff6579ce01a1820b3ff4f6c998/.github/workflows/continuous-deployment.yml#L147
[2]: https://github.com/flex-development/grease/blob/182fd184a7c64dff6579ce01a1820b3ff4f6c998/scripts/release.ts#L146
[P010-26]: https://flexdevelopment.atlassian.net/browse/P010-26